### PR TITLE
feat: adds facebook domain verification meta tag

### DIFF
--- a/edx-platform/israelxedu.gov.il/lms/templates/head-extra.html
+++ b/edx-platform/israelxedu.gov.il/lms/templates/head-extra.html
@@ -21,6 +21,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 <%static:css group='style-main-v2'/>
 
+<!-- Facebook Domain Verification -->
+<meta name="facebook-domain-verification" content="hwcacnnpfrdpuk8bvavf94s4321rmn" />
+
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This change adds the facebook domain verification meta tag to the LMS.

## Supporting information

* JIRA Tickets: SE-4453, CAM2-557

## Testing instructions

* Open the LMS
* Inspect the page
* Search for the meta tag with the following name: **`facebook-domain-verification`**
